### PR TITLE
Add calculate_AgaveSunset node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,19 @@
+"""AgaveSunset custom nodes for ComfyUI."""
+
+from .calculate_AgaveSunset import CalculateAgaveSunset
+from .type_AgaveSunset import TypeAgaveSunset
+
+NODE_CLASS_MAPPINGS = {
+    "type_AgaveSunset": TypeAgaveSunset,
+    "calculate_AgaveSunset": CalculateAgaveSunset,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "type_AgaveSunset": "type_AgaveSunset",
+    "calculate_AgaveSunset": "calculate_AgaveSunset",
+}
+
+__all__ = [
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+]

--- a/calculate_AgaveSunset.py
+++ b/calculate_AgaveSunset.py
@@ -1,0 +1,85 @@
+"""Calculation node definitions for AgaveSunset custom ComfyUI nodes."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict
+
+
+class CalculateAgaveSunset:
+    """Perform math expressions using up to three input variables."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "a": ("FLOAT", {"default": 0.0}),
+                "b": ("FLOAT", {"default": 0.0}),
+                "c": ("FLOAT", {"default": 0.0}),
+                "expression": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "a + b + c",
+                        "placeholder": "Enter a Python expression using a, b, c",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT",)
+    RETURN_NAMES = ("result",)
+    FUNCTION = "compute"
+    CATEGORY = "AgaveSunset"
+
+    def compute(self, a: float, b: float, c: float, expression: str):
+        """Evaluate the provided expression within a constrained environment."""
+
+        context = self._build_context(a=a, b=b, c=c)
+        try:
+            value = eval(expression, {"__builtins__": {}}, context)
+        except Exception as exc:  # pragma: no cover - runtime evaluation errors
+            raise ValueError(f"Failed to evaluate expression '{expression}': {exc}") from exc
+
+        if isinstance(value, (int, float)):
+            return (float(value),)
+
+        raise ValueError(
+            "Expression result must be a number; received " f"{type(value).__name__}."
+        )
+
+    def _build_context(self, **variables: float) -> Dict[str, Any]:
+        """Build the local evaluation context for the expression."""
+
+        math_functions = {
+            name: getattr(math, name)
+            for name in (
+                "ceil",
+                "floor",
+                "sqrt",
+                "log",
+                "log10",
+                "exp",
+                "sin",
+                "cos",
+                "tan",
+                "asin",
+                "acos",
+                "atan",
+                "sinh",
+                "cosh",
+                "tanh",
+                "pow",
+            )
+        }
+
+        safe_builtins = {
+            "abs": abs,
+            "max": max,
+            "min": min,
+            "round": round,
+        }
+
+        context: Dict[str, Any] = {**variables, **math_functions, **safe_builtins}
+        context["math"] = math
+        return context

--- a/type_AgaveSunset.py
+++ b/type_AgaveSunset.py
@@ -1,0 +1,34 @@
+"""Node definitions for AgaveSunset custom ComfyUI nodes."""
+
+from __future__ import annotations
+
+
+class TypeAgaveSunset:
+    """Combine common primitive type widgets into a single node."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "float_value": ("FLOAT", {"default": 0.0, "step": 0.01}),
+                "boolean_value": ("BOOLEAN", {"default": False}),
+                "string_value": ("STRING", {"default": ""}),
+                "int_value": ("INT", {"default": 0}),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "BOOLEAN", "STRING", "INT")
+    RETURN_NAMES = ("float", "boolean", "string", "int")
+    FUNCTION = "produce"
+    CATEGORY = "AgaveSunset"
+
+    def produce(
+        self,
+        float_value: float,
+        boolean_value: bool,
+        string_value: str,
+        int_value: int,
+    ):
+        """Return the configured primitive values."""
+
+        return float_value, boolean_value, string_value, int_value


### PR DESCRIPTION
## Summary
- add an __init__ entry point that registers the custom nodes
- implement the type_AgaveSunset node that outputs primitive type values from a single widget
- add the calculate_AgaveSunset node to evaluate math expressions between input variables

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d35db70b28832c969b3b10a06235c2